### PR TITLE
Export DBWrapper from datastore and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Node & package managers
+node_modules/
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Turbo repo caches
+.turbo/
+.turbo/cache/
+.turbo/cookies/
+
+# Build artifacts
+dist/
+build/
+coverage/
+tsconfig.tsbuildinfo
+packages/*/dist/
+packages/*/build/
+packages/*/coverage/
+packages/*/tsconfig.tsbuildinfo
+
+# Editor/OS noise
+*.swp
+*.swx
+*.DS_Store
+
+# Local state
+state/
+evtest
+xev.out

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ packages/*/tsconfig.tsbuildinfo
 *.swx
 *.DS_Store
 
-# Local state
-state/
-evtest
-xev.out
+# Local state (dev machine scratch files; safe to ignore if present)
+/state/
+/evtest
+/xev.out

--- a/README.md
+++ b/README.md
@@ -47,21 +47,7 @@ Here is an example of using `minitsis-node` for persistent storage:
 ```ts
 import { runTest, Random } from 'minitsis';
 import { NodeDataStore } from 'minitsis-node';
-import { Database } from 'minitsis-datastore';
-
-class DBWrapper implements Database {
-  constructor(private ds: NodeDataStore<string>) {}
-  async set(k: string, v: Uint8Array) {
-    await this.ds.set(k, Buffer.from(v).toString('base64'));
-  }
-  async get(k: string) {
-    const s = await this.ds.get(k);
-    return s ? Uint8Array.from(Buffer.from(s, 'base64')) : null;
-  }
-  async delete(k: string) {
-    await this.ds.delete(k);
-  }
-}
+import { DBWrapper } from 'minitsis-datastore';
 
 const database = new DBWrapper(new NodeDataStore<string>('./db'));
 await runTest(100, new Random(), database, false)(wrapWithName(testFn));

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,7 @@
             "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.23.5",
@@ -2862,6 +2863,7 @@
             "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -2974,6 +2976,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -3195,6 +3198,7 @@
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3608,6 +3612,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001587",
                 "electron-to-chromium": "^1.4.668",
@@ -4395,6 +4400,7 @@
             "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4452,6 +4458,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
             "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -5482,6 +5489,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
             "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -6296,6 +6304,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -9316,6 +9325,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -9579,6 +9589,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
             "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9972,10 +9983,10 @@
             }
         },
         "packages/minitsis": {
-            "version": "3.0.1",
+            "version": "6.0.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "minitsis-datastore": "^1.2.0",
+                "minitsis-datastore": "^1.3.1",
                 "uuid": "*"
             },
             "devDependencies": {
@@ -9984,7 +9995,7 @@
                 "jest": "^29.7.0",
                 "localforage": "^1.10.0",
                 "minitsis-browser": "*",
-                "minitsis-node": "^1.2.0",
+                "minitsis-node": "^1.3.0",
                 "nedb-promises": "^6.2.3",
                 "ts-jest": "^29.1.2",
                 "typescript": "~5.2.0"
@@ -9994,7 +10005,7 @@
             },
             "peerDependencies": {
                 "minitsis-browser": "*",
-                "minitsis-node": "^1.2.0"
+                "minitsis-node": "^1.3.0"
             }
         },
         "packages/miniTSis": {
@@ -10026,10 +10037,10 @@
             }
         },
         "packages/minitsis-browser": {
-            "version": "1.1.0",
+            "version": "1.3.0",
             "dependencies": {
                 "localforage": "^1.10.0",
-                "minitsis-datastore": "^1.1.0"
+                "minitsis-datastore": "^1.3.0"
             }
         },
         "packages/miniTSis-browser": {
@@ -10042,7 +10053,7 @@
             }
         },
         "packages/minitsis-datastore": {
-            "version": "1.1.0",
+            "version": "1.3.1",
             "license": "Apache-2.0",
             "devDependencies": {
                 "tsup": "^8.0.2",
@@ -10073,7 +10084,7 @@
             }
         },
         "packages/minitsis-node": {
-            "version": "1.1.0",
+            "version": "1.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "minitsis-datastore": "*",
@@ -10115,24 +10126,6 @@
             },
             "engines": {
                 "node": ">=14.17"
-            }
-        },
-        "packages/minitsis/node_modules/minitsis-datastore": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minitsis-datastore/-/minitsis-datastore-1.2.0.tgz",
-            "integrity": "sha512-JkOoR7Y3PufOB8Na/Zcy6Q9EDpgpuk5zCzFrkKT8ozYcV7Wa73rRfJgtUisXdVethp6Ex0uJfLTZWlkqBkOulw=="
-        },
-        "packages/minitsis/node_modules/minitsis-node": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minitsis-node/-/minitsis-node-1.2.0.tgz",
-            "integrity": "sha512-RYtI0hrNrgMsa4PtZIqxQoVsCAXW3X2EE/pyelYhhklqlkm1thQ3Q+DJdADwxuFUR51br7kyytS4FMv4IdmOmA==",
-            "dev": true,
-            "dependencies": {
-                "minitsis-datastore": "*",
-                "nedb-promises": "^6.2.3"
-            },
-            "engines": {
-                "node": ">=14.14.0"
             }
         },
         "packages/minitsis/node_modules/typescript": {

--- a/packages/minitsis-datastore/package.json
+++ b/packages/minitsis-datastore/package.json
@@ -1,6 +1,6 @@
 {
     "name": "minitsis-datastore",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
@@ -22,6 +22,11 @@
             "types": "./dist/index.d.ts",
             "import": "./dist/index.mjs",
             "require": "./dist/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "*": ["./dist/index.d.ts"]
         }
     }
 }

--- a/packages/minitsis-datastore/package.json
+++ b/packages/minitsis-datastore/package.json
@@ -18,7 +18,10 @@
         "typescript": "~5.2.0"
     },
     "exports": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.js"
+        }
     }
 }

--- a/packages/minitsis-datastore/src/index.ts
+++ b/packages/minitsis-datastore/src/index.ts
@@ -11,7 +11,7 @@ export interface Database {
   set(key: string, value: Uint8Array): Promise<void>;
   get(key: string): Promise<Uint8Array | null>;
   delete(key: string): Promise<void>;
-  count?(): Promise<number>;
+  count(): Promise<number>;
 }
 
 function hasNodeBuffer(): boolean {
@@ -24,12 +24,17 @@ function encodeBase64(data: Uint8Array): string {
   }
 
   if (typeof globalThis === 'object' && 'btoa' in globalThis) {
-    // btoa expects a binary string, so construct one in small chunks to avoid stack issues
-    let binary = '';
-    for (let i = 0; i < data.length; i++) {
-      binary += String.fromCharCode(data[i]);
+    // btoa expects a binary string; build it in chunks to avoid quadratic growth
+    // and keep argument sizes safe for String.fromCharCode.
+    const chunkSize = 8192;
+    const chunks: string[] = [];
+    for (let i = 0; i < data.length; i += chunkSize) {
+      const slice = data.subarray(i, i + chunkSize);
+      chunks.push(String.fromCharCode(...slice));
     }
-    return (globalThis as unknown as {btoa(data: string): string}).btoa(binary);
+    return (globalThis as unknown as {btoa(data: string): string}).btoa(
+      chunks.join('')
+    );
   }
 
   throw new Error('No base64 encoder available in the current environment.');
@@ -80,9 +85,6 @@ export class DBWrapper implements Database {
   }
 
   async count(): Promise<number> {
-    if (!this.dataStore.count) {
-      throw new Error('Underlying data store does not implement count().');
-    }
     return this.dataStore.count();
   }
 }

--- a/packages/minitsis-datastore/src/index.ts
+++ b/packages/minitsis-datastore/src/index.ts
@@ -11,4 +11,78 @@ export interface Database {
   set(key: string, value: Uint8Array): Promise<void>;
   get(key: string): Promise<Uint8Array | null>;
   delete(key: string): Promise<void>;
+  count?(): Promise<number>;
+}
+
+function hasNodeBuffer(): boolean {
+  return typeof Buffer !== 'undefined';
+}
+
+function encodeBase64(data: Uint8Array): string {
+  if (hasNodeBuffer()) {
+    return Buffer.from(data).toString('base64');
+  }
+
+  if (typeof globalThis === 'object' && 'btoa' in globalThis) {
+    // btoa expects a binary string, so construct one in small chunks to avoid stack issues
+    let binary = '';
+    for (let i = 0; i < data.length; i++) {
+      binary += String.fromCharCode(data[i]);
+    }
+    return (globalThis as unknown as {btoa(data: string): string}).btoa(binary);
+  }
+
+  throw new Error('No base64 encoder available in the current environment.');
+}
+
+function decodeBase64(encoded: string): Uint8Array {
+  if (hasNodeBuffer()) {
+    return Uint8Array.from(Buffer.from(encoded, 'base64'));
+  }
+
+  if (typeof globalThis === 'object' && 'atob' in globalThis) {
+    const binary = (globalThis as unknown as {atob(data: string): string}).atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  throw new Error('No base64 decoder available in the current environment.');
+}
+
+export function toBase64(data: Uint8Array): string {
+  return encodeBase64(data);
+}
+
+export function fromBase64(encoded: string): Uint8Array {
+  return decodeBase64(encoded);
+}
+
+// Utility wrapper that adapts an IDataStore storing strings into the Database interface
+// used by minitsis. Values are base64-encoded so we can transport Uint8Arrays.
+export class DBWrapper implements Database {
+  constructor(private readonly dataStore: IDataStore<string>) {}
+
+  async set(key: string, value: Uint8Array): Promise<void> {
+    const base64Value = toBase64(value);
+    await this.dataStore.set(key, base64Value);
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    const base64Value = await this.dataStore.get(key);
+    return base64Value ? fromBase64(base64Value) : null;
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.dataStore.delete(key);
+  }
+
+  async count(): Promise<number> {
+    if (!this.dataStore.count) {
+      throw new Error('Underlying data store does not implement count().');
+    }
+    return this.dataStore.count();
+  }
 }

--- a/packages/minitsis/package.json
+++ b/packages/minitsis/package.json
@@ -21,7 +21,7 @@
         "node": ">=14.14.0"
     },
     "dependencies": {
-        "minitsis-datastore": "^1.3.0",
+        "minitsis-datastore": "^1.3.1",
         "uuid": "*"
     },
     "peerDependencies": {

--- a/packages/minitsis/src/index.test.ts
+++ b/packages/minitsis/src/index.test.ts
@@ -51,41 +51,7 @@ import {
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { Database, IDataStore } from 'minitsis-datastore';
-
-class DBWrapper implements Database {
-  private dataStore: IDataStore<string>;
-
-  constructor(dataStore: IDataStore<string>) {
-    this.dataStore = dataStore;
-  }
-
-  async set(key: string, value: Uint8Array): Promise<void> {
-    const base64Value = toBase64(value);
-    await this.dataStore.set(key, base64Value);
-  }
-
-  async get(key: string): Promise<Uint8Array | null> {
-    const base64Value = await this.dataStore.get(key);
-    return base64Value ? fromBase64(base64Value) : null;
-  }
-
-  async delete(key: string): Promise<void> {
-    await this.dataStore.delete(key);
-  }
-
-  async count(): Promise<number> {
-    return await this.dataStore.count();
-  }
-}
-
-function toBase64(arrayBuffer: Uint8Array): string {
-  return Buffer.from(arrayBuffer).toString('base64');
-}
-
-function fromBase64(base64String: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(base64String, 'base64'));
-}
+import { Database, DBWrapper, IDataStore } from 'minitsis-datastore';
 import { BrowserDataStore } from 'minitsis-browser';
 import { NodeDataStore } from 'minitsis-node';
 

--- a/packages/minitsis/src/index.test.ts
+++ b/packages/minitsis/src/index.test.ts
@@ -16,6 +16,10 @@ class MapDB implements Database {
   async delete(key: string): Promise<void> {
     this.data.delete(key);
   }
+
+  async count(): Promise<number> {
+    return this.data.size;
+  }
 }
 
 import {


### PR DESCRIPTION
## Summary
- move DBWrapper and base64 helpers into minitsis-datastore so downstream packages can reuse it
- update minitsis tests/README to import the shared wrapper
- add a repo-level .gitignore for node_modules, turbo caches, and build artifacts

## Testing
- npm test --workspace minitsis
