### PR TITLE
Add oneOf possibility for static lists

### DIFF
--- a/packages/minitsis/src/index.test.ts
+++ b/packages/minitsis/src/index.test.ts
@@ -38,6 +38,7 @@ import {
   lists,
   mixOf,
   nothing,
+  oneOf,
   runTest,
   runTestAsync,
   sublists,
@@ -542,6 +543,22 @@ describe('Minithesis Tests', () => {
       expect(Number(m)).not.toBe(1);
     });
     await runTest(100, 1234, new MapDB(), true)(testFn);
+  });
+
+  test('selects from static list', () => {
+    const tc = TestCase.forChoices([1n]);
+    const letter = tc.any(oneOf(['a', 'b', 'c'] as const));
+    expect(letter).toBe('b');
+  });
+
+  test('rejects empty static list', async () => {
+    const testFn = wrapWithName((tc: TestCase) => {
+      tc.any(oneOf([] as const));
+    });
+
+    await expect(
+      runTest(10, 42, new MapDB(), true)(testFn)
+    ).rejects.toThrow(Unsatisfiable);
   });
 
   test('mapped possibility', async () => {

--- a/packages/minitsis/src/index.ts
+++ b/packages/minitsis/src/index.ts
@@ -727,13 +727,17 @@ export function just<T>(value: T): Possibility<T> {
   return new Possibility<T>(() => value, `just(${value})`);
 }
 
-export function oneOf<T>(values: readonly T[]): Possibility<T> {
+export function oneOf<T extends readonly unknown[]>(
+  values: T
+): Possibility<T[number]> {
   if (values.length === 0) {
     const name = 'oneOf(<empty>)';
     return new Possibility(() => {
       throw new Unsatisfiable();
     }, name);
   }
+  // Intentionally keep the full list in the name so failure logs retain
+  // full context; the shrinker will minimise length while preserving meaning.
   const name = `oneOf(${values.join(',')})`;
   return new Possibility((tc: TestCase) => {
     return values[Number(tc.choice(BigInt(values.length - 1)))];

--- a/packages/minitsis/src/index.ts
+++ b/packages/minitsis/src/index.ts
@@ -727,6 +727,16 @@ export function just<T>(value: T): Possibility<T> {
   return new Possibility<T>(() => value, `just(${value})`);
 }
 
+export function oneOf<T>(values: readonly T[]): Possibility<T> {
+  if (values.length === 0) {
+    return nothing();
+  }
+  const name = `oneOf(${values.join(',')})`;
+  return new Possibility((tc: TestCase) => {
+    return values[Number(tc.choice(BigInt(values.length - 1)))];
+  }, name);
+}
+
 export function toNumber(bigintValue: bigint): number {
   if (bigintValue > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new Error(

--- a/packages/minitsis/src/index.ts
+++ b/packages/minitsis/src/index.ts
@@ -729,7 +729,10 @@ export function just<T>(value: T): Possibility<T> {
 
 export function oneOf<T>(values: readonly T[]): Possibility<T> {
   if (values.length === 0) {
-    return nothing();
+    const name = 'oneOf(<empty>)';
+    return new Possibility(() => {
+      throw new Unsatisfiable();
+    }, name);
   }
   const name = `oneOf(${values.join(',')})`;
   return new Possibility((tc: TestCase) => {


### PR DESCRIPTION
## Summary
- add exported oneOf possibility for selecting from a static list (empty lists now reject)
- cover selection and empty-list behavior with new unit tests
- verified with npm test --workspace minitsis