### PR TITLE
ci: pin changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = context.payload.workflow_run.head_sha;
+            const sha = context.payload.workflow_run?.head_sha || context.sha;
             const required = ["Node Adapter CI", "Browser Adapter CI"];
             const {data} = await github.rest.checks.listForRef({
               owner: context.repo.owner,
@@ -45,19 +45,23 @@ jobs:
             }
 
             core.exportVariable('TARGET_SHA', sha);
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ env.TARGET_SHA || github.event.workflow_run.head_sha }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
       - name: Install
         run: npm ci
+
       - name: Build and publish with Changesets (OIDC)
-        uses: changesets/action@v2
+        uses: changesets/action@v1.6.2
         with:
           publish: "NPM_CONFIG_PROVENANCE=true npm run publish-packages"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,10 @@ jobs:
             }
 
             core.exportVariable('TARGET_SHA', sha);
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ env.TARGET_SHA || github.event.workflow_run.head_sha }}
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Pin changesets/action to v1.6.2 so release workflow can resolve and publish via OIDC. No other changes.