### PR TITLE
ci: pin changesets action to v1.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm ci
 
       - name: Build and publish with Changesets (OIDC)
-        uses: changesets/action@v1.6.2
+        uses: changesets/action@v1.5.3
         with:
           publish: "NPM_CONFIG_PROVENANCE=true npm run publish-packages"
         env:


### PR DESCRIPTION
Resolve release workflow failure: use latest published tag changesets/action@v1.5.3 (v1.6.2 tag doesn’t exist).