### PR TITLE
fix/release workflow pin v2

### DIFF
--- a/.changeset/publish-workflow-fix.md
+++ b/.changeset/publish-workflow-fix.md
@@ -1,7 +1,0 @@
----
-"@minitsis/core": patch
-"minitsis-node": patch
-"minitsis-browser": patch
-"minitsis-datastore": patch
----
-Align release workflow so publishes only proceed after both node and browser CI succeed and fail fast if either is skipped.

--- a/.changeset/publish-workflow-fix.md
+++ b/.changeset/publish-workflow-fix.md
@@ -1,0 +1,7 @@
+---
+"@minitsis/core": patch
+"minitsis-node": patch
+"minitsis-browser": patch
+"minitsis-datastore": patch
+---
+Align release workflow so publishes only proceed after both node and browser CI succeed and fail fast if either is skipped.

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -50,6 +50,7 @@ jobs:
         id: changesets
         run: |
           set -euo pipefail
+          npm install --no-save @changesets/cli
           STATUS=$(npx changeset status --output=stdout)
           if ! command -v jq >/dev/null 2>&1; then
             echo "::error::jq is required for changeset detection" >&2

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -22,7 +22,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [node, browser]
+<<<<<<< HEAD
     timeout-minutes: 10
+||||||| parent of db79c07 (ci: guard release on ci results)
+    timeout-minutes: 20
+    if: needs.node.result == 'success' && needs.browser.result == 'success'
+=======
+    timeout-minutes: 20
+>>>>>>> db79c07 (ci: guard release on ci results)
     if: always()
     steps:
       - name: Verify CI results
@@ -30,6 +37,7 @@ jobs:
           set -euo pipefail
           echo "Node result: ${{ needs.node.result }}"
           echo "Browser result: ${{ needs.browser.result }}"
+<<<<<<< HEAD
           if [ "${{ needs.node.result }}" = "skipped" ] || [ "${{ needs.browser.result }}" = "skipped" ]; then
             which_skipped=""
             [ "${{ needs.node.result }}" = "skipped" ] && which_skipped="Node"
@@ -37,6 +45,9 @@ jobs:
             echo "::error::Release blocked because ${which_skipped} CI was skipped; ensure both node and browser workflows run for this commit."
             exit 1
           fi
+||||||| parent of db79c07 (ci: guard release on ci results)
+=======
+>>>>>>> db79c07 (ci: guard release on ci results)
           if [ "${{ needs.node.result }}" != "success" ] || [ "${{ needs.browser.result }}" != "success" ]; then
             echo "::error::Release blocked because required CI jobs did not succeed."
             exit 1
@@ -65,6 +76,15 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      - name: Verify publish token available
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: |
+          set -euo pipefail
+          if [ -z "${GITHUB_TOKEN:-}" ]; then
+            echo "::error::GITHUB_TOKEN is required for publishing."
+            exit 1
+          fi
 
       - name: Install
         if: steps.changesets.outputs.has_changesets == 'true'

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -22,14 +22,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [node, browser]
-<<<<<<< HEAD
     timeout-minutes: 10
-||||||| parent of db79c07 (ci: guard release on ci results)
-    timeout-minutes: 20
-    if: needs.node.result == 'success' && needs.browser.result == 'success'
-=======
-    timeout-minutes: 20
->>>>>>> db79c07 (ci: guard release on ci results)
     if: always()
     steps:
       - name: Verify CI results
@@ -37,7 +30,6 @@ jobs:
           set -euo pipefail
           echo "Node result: ${{ needs.node.result }}"
           echo "Browser result: ${{ needs.browser.result }}"
-<<<<<<< HEAD
           if [ "${{ needs.node.result }}" = "skipped" ] || [ "${{ needs.browser.result }}" = "skipped" ]; then
             which_skipped=""
             [ "${{ needs.node.result }}" = "skipped" ] && which_skipped="Node"
@@ -45,9 +37,6 @@ jobs:
             echo "::error::Release blocked because ${which_skipped} CI was skipped; ensure both node and browser workflows run for this commit."
             exit 1
           fi
-||||||| parent of db79c07 (ci: guard release on ci results)
-=======
->>>>>>> db79c07 (ci: guard release on ci results)
           if [ "${{ needs.node.result }}" != "success" ] || [ "${{ needs.browser.result }}" != "success" ]; then
             echo "::error::Release blocked because required CI jobs did not succeed."
             exit 1
@@ -76,15 +65,6 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
-
-      - name: Verify publish token available
-        if: steps.changesets.outputs.has_changesets == 'true'
-        run: |
-          set -euo pipefail
-          if [ -z "${GITHUB_TOKEN:-}" ]; then
-            echo "::error::GITHUB_TOKEN is required for publishing."
-            exit 1
-          fi
 
       - name: Install
         if: steps.changesets.outputs.has_changesets == 'true'


### PR DESCRIPTION
- **ci: orchestrate main release via single workflow and pin changesets action**
- **ci: guard release on ci results**
- **ci: fail fast when adapter CI skipped**
- **chore: add changeset for release workflow fix**
- **chore: add aggregate changeset for recent releases**
- **ci: clarify skipped job message and use jq for changesets when available**
- **ci: require jq for changeset detection**
- **ci: install changesets cli in release job**
